### PR TITLE
add remote_schema_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Optional settings:
 
 - `remote_schema_headers` - extra headers that are passed along with introspection query, eg. `{"Authorization" = "Bearer: token"}`. To include an environment variable in a header value, prefix the variable with `$`, eg. `{"Authorization" = "$AUTH_TOKEN"}`
 - `remote_schema_verify_ssl` (defaults to `true`) - a flag that specifies wheter to verify ssl while introspecting remote schema
+- `remote_schema_timeout` (defaults to `5`) - timeout in seconds while introspecting remote schema
 - `target_package_name` (defaults to `"graphql_client"`) - name of generated package
 - `target_package_path` (defaults to cwd) - path where to generate package
 - `client_name` (defaults to `"Client"`) - name of generated client class
@@ -418,7 +419,7 @@ Instead of generating a client, you can generate a file with a copy of a GraphQL
 ariadne-codegen graphqlschema
 ```
 
-`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl` options to retrieve the schema and `plugins` option to load plugins.
+`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl`, `remote_schema_timeout` options to retrieve the schema and `plugins` option to load plugins.
 
 In addition to the above, `graphqlschema` mode also accepts additional settings specific to it:
 

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -50,6 +50,7 @@ def client(config_dict):
             url=settings.remote_schema_url,
             headers=settings.remote_schema_headers,
             verify_ssl=settings.remote_schema_verify_ssl,
+            timeout=settings.remote_schema_timeout
         )
 
     plugin_manager = PluginManager(
@@ -93,6 +94,7 @@ def graphql_schema(config_dict):
             url=settings.remote_schema_url,
             headers=settings.remote_schema_headers,
             verify_ssl=settings.remote_schema_verify_ssl,
+            timeout=settings.remote_schema_timeout
         )
     )
     plugin_manager = PluginManager(

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -63,16 +63,24 @@ def get_graphql_queries(
 
 
 def get_graphql_schema_from_url(
-    url: str, headers: Optional[Dict[str, str]] = None, verify_ssl: bool = True
+    url: str,
+    headers: Optional[Dict[str, str]] = None,
+    verify_ssl: bool = True,
+    timeout: float = 5,
 ) -> GraphQLSchema:
     return build_client_schema(
-        introspect_remote_schema(url=url, headers=headers, verify_ssl=verify_ssl),
+        introspect_remote_schema(
+            url=url, headers=headers, verify_ssl=verify_ssl, timeout=timeout
+        ),
         assume_valid=True,
     )
 
 
 def introspect_remote_schema(
-    url: str, headers: Optional[Dict[str, str]] = None, verify_ssl: bool = True
+    url: str,
+    headers: Optional[Dict[str, str]] = None,
+    verify_ssl: bool = True,
+    timeout: float = 5,
 ) -> IntrospectionQuery:
     try:
         response = httpx.post(
@@ -80,6 +88,7 @@ def introspect_remote_schema(
             json={"query": get_introspection_query(descriptions=False)},
             headers=headers,
             verify=verify_ssl,
+            timeout=timeout,
         )
     except httpx.InvalidURL as exc:
         raise IntrospectionError(f"Invalid remote schema url: {url}") from exc

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -37,6 +37,7 @@ class BaseSettings:
     remote_schema_url: str = ""
     remote_schema_headers: dict = field(default_factory=dict)
     remote_schema_verify_ssl: bool = True
+    remote_schema_timeout: float = 5
     enable_custom_operations: bool = False
     plugins: List[str] = field(default_factory=list)
 

--- a/tests/client_generators/package_generator/test_generator_generation.py
+++ b/tests/client_generators/package_generator/test_generator_generation.py
@@ -45,6 +45,7 @@ def test_get_package_generator_without_default_settings(tmp_path: Path):
         remote_schema_url="remote_schema_url",
         remote_schema_headers={"header": "header"},
         remote_schema_verify_ssl=False,
+        remote_schema_timeout=5,
         enable_custom_operations=True,
         plugins=["imaplugin"],
         queries_path=schema_path.as_posix(),


### PR DESCRIPTION
 The default timeout for `httpx` used by `ariadne-codegen` is 5 seconds.
 By adding the `remote_schema_timeout` option, you can control the timeout duration.